### PR TITLE
Add uses-sdk to AndroidManifest.xml

### DIFF
--- a/wizardroid-sample/AndroidManifest.xml
+++ b/wizardroid-sample/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.codepond.android.wizardroid" android:versionCode="1" android:versionName="1.0-SNAPSHOT">
-
+  
+  <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="17" />
   <application android:icon="@drawable/icon" android:label="@string/app_name">
     <activity android:name=".MainActivity">
       <intent-filter>


### PR DESCRIPTION
Currently the sample looks like this on a Nexus 4:
![screenshot_2013-06-19-06-39-53](https://f.cloud.github.com/assets/1798519/672999/d04ae526-d8a3-11e2-87df-a6c1ee884d7c.png)

The app is ignoring screen density. Adding a uses-sdk to AndroidManifest.xml makes it take into account screen density (and use the device default theme):
![screenshot_2013-06-19-06-40-55](https://f.cloud.github.com/assets/1798519/673003/d55327fe-d8a3-11e2-9955-d8dfcc7cd98b.png)
