### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/wizardroid/src/main/AndroidManifest.xml
+++ b/wizardroid/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="4" android:versionName="1.1.1" package="org.codepond.wizardroid">
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="19"/>
     <application/>
 </manifest>


### PR DESCRIPTION
Remove SDK from Manifest.  These values are not used, as the gradle build overrides them.   These values might be aggravating a Android Studio manifest merge bug when including the repo in a project with a different targetSDK.
