### PR TITLE
Several improvements to WizardFragment

### DIFF
--- a/wizardroid/src/main/java/org/codepond/wizardroid/WizardFragment.java
+++ b/wizardroid/src/main/java/org/codepond/wizardroid/WizardFragment.java
@@ -28,8 +28,41 @@ public abstract class WizardFragment extends Fragment implements Wizard.WizardCa
 
     protected Wizard wizard;
 
-    public WizardFragment() {
+    public BasicWizard() {
+        this.contextManager = new ContextManagerImpl();
+    }
 
+    /**
+     * @param contextManager {@link ContextManager}, responsible for persisting variable values between steps
+     */
+    public BasicWizard(ContextManager contextManager) {
+        this.contextManager = contextManager;
+    }
+
+    /**
+     * Called during step switch. Default implementation hides keyboard.
+     **/
+    @Override
+    public void onStepChanged() {
+        // in order to hide software input method we need to authorize with window token from focused window
+        // this code relies on (somewhat fragile) assumption, that the only window, that can hold
+        // software keyboard focus during fragment switch, one with fragment itself.
+        final InputMethodManager mgr = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+
+        View focusedWindowChild = wizard.getCurrentStep().getView();
+        if (focusedWindowChild == null)
+            focusedWindowChild = getActivity().getCurrentFocus();
+        if (focusedWindowChild == null)
+            focusedWindowChild = new View(getActivity());
+        mgr.hideSoftInputFromWindow(focusedWindowChild.getWindowToken(), 0);
+    }
+    
+    /**
+     * @return {@link Wizard}, associated with this fragment. Children fragments should not need to
+     * access it directly, unless certain degree of automation is needed.
+     */
+    public Wizard getWizard() {
+        return wizard;
     }
 
     @Override


### PR DESCRIPTION
Hide software keyboard during fragment switch; expose underlying Wizard and ContextManager to allow switching steps from inside child fragments and make possible alternative ContextManager implementations.
